### PR TITLE
Add multi-home support to YoLink integration via UAC authentication

### DIFF
--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -157,7 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # OAuth2 authentication (existing behavior)
         try:
             implementation = await async_get_config_entry_implementation(hass, entry)
-        except (ImplementationUnavailableError, ValueError) as err:
+        except ImplementationUnavailableError as err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="oauth2_implementation_unavailable",

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -23,10 +23,17 @@ from homeassistant.helpers import (
     device_registry as dr,
 )
 from homeassistant.helpers.config_entry_oauth2_flow import (
-    ImplementationUnavailableError,
     OAuth2Session,
     async_get_config_entry_implementation,
 )
+
+# Compatibility for older HA versions
+try:
+    from homeassistant.helpers.config_entry_oauth2_flow import (
+        ImplementationUnavailableError,
+    )
+except ImportError:
+    ImplementationUnavailableError = ValueError
 from homeassistant.helpers.typing import ConfigType
 
 from . import api
@@ -150,7 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # OAuth2 authentication (existing behavior)
         try:
             implementation = await async_get_config_entry_implementation(hass, entry)
-        except ImplementationUnavailableError as err:
+        except (ImplementationUnavailableError, ValueError) as err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="oauth2_implementation_unavailable",

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from yolink.auth_mgr import YoLinkAuthMgr
 from yolink.const import OAUTH2_TOKEN
 from yolink.exception import YoLinkAuthFailError, YoLinkClientError
@@ -131,6 +131,6 @@ class UACAuth(YoLinkAuthMgr):
         except YoLinkClientError:
             _LOGGER.error("Client error during token fetch")
             raise
-        except Exception as err:
-            _LOGGER.exception("Unexpected error during token fetch: %s", err)
+        except ClientError as err:
+            _LOGGER.error("Network error during token fetch: %s", err)
             raise YoLinkClientError(f"Failed to fetch token: {err}") from err

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -96,6 +96,7 @@ class UACAuth(YoLinkAuthMgr):
         """Return a valid access token."""
         if self._access_token is None:
             await self._fetch_token()
+        assert self._access_token is not None
         return self._access_token
 
     async def _fetch_token(self) -> None:

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -1,7 +1,9 @@
-"""API for yolink bound to Home Assistant OAuth."""
+"""API for yolink bound to Home Assistant OAuth or UAC."""
 
 from aiohttp import ClientSession
 from yolink.auth_mgr import YoLinkAuthMgr
+from yolink.const import OAUTH2_TOKEN
+from yolink.local_auth_mgr import YoLinkLocalAuthMgr
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -29,3 +31,23 @@ class ConfigEntryAuth(YoLinkAuthMgr):
         """Check the token."""
         await self.oauth_session.async_ensure_token_valid()
         return self.access_token()
+
+
+class UACAuth(YoLinkLocalAuthMgr):
+    """Provide yolink authentication using UAC (User Access Credentials)."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        websession: ClientSession,
+        uaid: str,
+        secret_key: str,
+    ) -> None:
+        """Initialize yolink UAC Auth."""
+        self.hass = hass
+        super().__init__(
+            session=websession,
+            token_url=OAUTH2_TOKEN,
+            client_id=uaid,
+            client_secret=secret_key,
+        )

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -16,7 +16,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ConfigEntryAuth(YoLinkAuthMgr):
-    """Provide yolink authentication tied to an OAuth2 based config entry."""
+    """Provide yolink authentication tied to an OAuth2 based config entry.
+
+    Implementation Notes (yolink-api 0.5.9):
+    - Uses YoLinkAuthMgr base class for OAuth2 token management.
+    - Token refresh is handled by Home Assistant's OAuth2Session.
+    - access_token() must be a method (not property) because the library
+      calls it as self.access_token() in http_auth_header().
+    """
 
     def __init__(
         self,
@@ -45,7 +52,22 @@ class ConfigEntryAuth(YoLinkAuthMgr):
 
 
 class UACAuth(YoLinkAuthMgr):
-    """Provide yolink authentication using UAC credentials."""
+    """Provide yolink authentication using UAC credentials.
+
+    Implementation Notes (yolink-api 0.5.9):
+    - Uses YoLinkAuthMgr base class because YoLinkLocalAuthMgr is not available
+      in yolink-api 0.5.9. Future versions may have YoLinkLocalAuthMgr which
+      handles token fetching automatically.
+    - access_token() must be a method (not property) because the library calls
+      it as self.access_token() in http_auth_header().
+    - Token fetching is implemented manually via _fetch_token() using the
+      client_credentials OAuth2 grant type.
+
+    For yolink-api >= 0.6.0 (if YoLinkLocalAuthMgr becomes available):
+    - Consider switching to YoLinkLocalAuthMgr as base class
+    - Remove manual token fetching logic
+    - Update to use super().__init__() with token_url, client_id, client_secret
+    """
 
     def __init__(
         self,

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -2,22 +2,51 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import Any
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
-from homeassistant.helpers import config_entry_oauth2_flow
+import voluptuous as vol
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+from yolink.home_manager import YoLinkHome
 
-from .const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
+
+from .api import UACAuth
+from .const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+UAC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_UAID): str,
+        vol.Required(CONF_SECRET_KEY): str,
+    }
+)
 
 
 class OAuth2FlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
 ):
-    """Config flow to handle yolink OAuth2 authentication."""
+    """Config flow to handle yolink OAuth2 and UAC authentication."""
 
     DOMAIN = DOMAIN
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self._home_id: str | None = None
+        self._home_name: str | None = None
 
     @property
     def logger(self) -> logging.Logger:
@@ -25,10 +54,90 @@ class OAuth2FlowHandler(
         return logging.getLogger(__name__)
 
     @property
-    def extra_authorize_data(self) -> dict:
+    def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
-        scopes = ["create"]
-        return {"scope": " ".join(scopes)}
+        return {"scope": "create"}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow start - show menu to choose auth method."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["pick_implementation", "uac"],
+        )
+
+    async def async_step_uac(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle UAC credential input."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                home_info = await self._async_validate_uac_credentials(
+                    user_input[CONF_UAID],
+                    user_input[CONF_SECRET_KEY],
+                )
+            except YoLinkAuthFailError:
+                errors["base"] = "invalid_auth"
+            except (YoLinkClientError, TimeoutError):
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during UAC validation")
+                errors["base"] = "unknown"
+            else:
+                self._home_id = home_info["id"]
+                self._home_name = home_info.get("name", "YoLink Home")
+
+                # Use home_id as unique identifier to allow multiple homes
+                await self.async_set_unique_id(self._home_id)
+
+                if self.source == SOURCE_REAUTH:
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    return self.async_update_reload_and_abort(
+                        self._get_reauth_entry(),
+                        data_updates={
+                            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+                            CONF_UAID: user_input[CONF_UAID],
+                            CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                            CONF_HOME_ID: self._home_id,
+                        },
+                    )
+
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=self._home_name,
+                    data={
+                        CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+                        CONF_UAID: user_input[CONF_UAID],
+                        CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                        CONF_HOME_ID: self._home_id,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="uac",
+            data_schema=UAC_SCHEMA,
+            errors=errors,
+        )
+
+    async def _async_validate_uac_credentials(
+        self, uaid: str, secret_key: str
+    ) -> dict[str, Any]:
+        """Validate UAC credentials and return home info."""
+        websession = aiohttp_client.async_get_clientsession(self.hass)
+        auth_mgr = UACAuth(self.hass, websession, uaid, secret_key)
+
+        yolink_home = YoLinkHome()
+        async with asyncio.timeout(10):
+            # Pass None for message_listener during validation
+            await yolink_home.async_setup(auth_mgr, None)
+            home_info = await yolink_home.async_get_home_info()
+            await yolink_home.async_unload()
+
+        return home_info.data
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -36,25 +145,33 @@ class OAuth2FlowHandler(
         """Perform reauth upon an API authentication error."""
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None) -> ConfigFlowResult:
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
-        return await self.async_step_user()
 
-    async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
+        # Check auth type of existing entry and route appropriately
+        reauth_entry = self._get_reauth_entry()
+        if reauth_entry.data.get(CONF_AUTH_TYPE) == AUTH_TYPE_UAC:
+            return await self.async_step_uac()
+        # For OAuth, use the standard OAuth flow (call without user_input to start fresh)
+        return await super().async_step_user()
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), data_updates=data
+                self._get_reauth_entry(),
+                data_updates={**data, CONF_AUTH_TYPE: AUTH_TYPE_OAUTH},
             )
-        return self.async_create_entry(title="YoLink", data=data)
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow start."""
+        # For OAuth entries, use DOMAIN as unique_id (backwards compatible)
+        # This limits OAuth to one entry, but UAC entries are unlimited
         existing_entry = await self.async_set_unique_id(DOMAIN)
-        if existing_entry and self.source != SOURCE_REAUTH:
+        if existing_entry:
             return self.async_abort(reason="already_configured")
-        return await super().async_step_user(user_input)
+
+        data[CONF_AUTH_TYPE] = AUTH_TYPE_OAUTH
+        return self.async_create_entry(title="YoLink", data=data)

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -153,7 +153,11 @@ class OAuth2FlowHandler(
             await yolink_home.async_setup(auth_mgr, _NoOpMessageListener())
             _LOGGER.debug("async_setup completed, getting home info...")
             home_info = await yolink_home.async_get_home_info()
-            _LOGGER.debug("Got home info: %s", home_info.data)
+            _LOGGER.debug(
+                "Got home info: id=%s, name=%s",
+                home_info.data.get("id"),
+                home_info.data.get("name"),
+            )
             await yolink_home.async_unload()
 
         return home_info.data

--- a/homeassistant/components/yolink/const.py
+++ b/homeassistant/components/yolink/const.py
@@ -51,3 +51,13 @@ SUPPORTED_REMOTERS = [
     DEV_MODEL_FLEX_FOB_YS3614_EC,
     DEV_MODEL_FLEX_FOB_YS3614_UC,
 ]
+
+# Authentication types
+CONF_AUTH_TYPE = "auth_type"
+AUTH_TYPE_OAUTH = "oauth"
+AUTH_TYPE_UAC = "uac"
+
+# UAC configuration
+CONF_UAID = "uaid"
+CONF_SECRET_KEY = "secret_key"
+CONF_HOME_ID = "home_id"

--- a/homeassistant/components/yolink/manifest.json
+++ b/homeassistant/components/yolink/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "yolink",
   "name": "YoLink",
+  "version": "2.0.0",
   "codeowners": ["@matrixd2"],
   "config_flow": true,
   "dependencies": ["auth", "application_credentials"],

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -11,12 +11,37 @@
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "The credentials provided are for a different YoLink home"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     },
     "step": {
+      "user": {
+        "description": "Choose how you want to authenticate with YoLink.",
+        "menu_options": {
+          "pick_implementation": "Sign in with YoLink account",
+          "uac": "Use UAC credentials (recommended for multiple homes)"
+        }
+      },
+      "uac": {
+        "title": "Enter UAC credentials",
+        "description": "Enter your User Access Credentials from the YoLink app.\n\nTo find these: YoLink App -> Settings -> Account -> Advanced Settings -> User Access Credentials",
+        "data": {
+          "uaid": "UAID (User Access ID)",
+          "secret_key": "Secret key"
+        },
+        "data_description": {
+          "uaid": "The User Access ID from your YoLink app",
+          "secret_key": "The secret key associated with your UAID"
+        }
+      },
       "pick_implementation": {
         "data": {
           "implementation": "[%key:common::config_flow::data::implementation%]"

--- a/tests/components/yolink/conftest.py
+++ b/tests/components/yolink/conftest.py
@@ -12,7 +12,14 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.yolink.api import ConfigEntryAuth
+from homeassistant.components.yolink.api import ConfigEntryAuth, UACAuth
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -21,6 +28,12 @@ from tests.common import MockConfigEntry
 CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
+
+# UAC test credentials
+TEST_UAID = "test-uaid-12345"
+TEST_SECRET_KEY = "test-secret-key-6789"
+TEST_HOME_ID = "home_12345"
+TEST_HOME_NAME = "My Test Home"
 
 
 @pytest.fixture
@@ -75,3 +88,47 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     )
     config_entry.add_to_hass(hass)
     return config_entry
+
+
+@pytest.fixture
+def mock_uac_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Mock a UAC config entry for YoLink."""
+    config_entry = MockConfigEntry(
+        unique_id=TEST_HOME_ID,
+        domain=DOMAIN,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+        options={},
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.fixture(name="mock_uac_auth_manager")
+def mock_uac_auth_manager() -> Generator[MagicMock]:
+    """Mock the UAC authentication manager."""
+    with patch(
+        "homeassistant.components.yolink.api.UACAuth", autospec=True
+    ) as mock_auth:
+        mock_auth.return_value = MagicMock(spec=UACAuth)
+        yield mock_auth
+
+
+@pytest.fixture(name="mock_yolink_home_config_flow")
+def mock_yolink_home_config_flow() -> Generator[AsyncMock]:
+    """Mock YoLink home instance for config flow."""
+    with patch(
+        "homeassistant.components.yolink.config_flow.YoLinkHome", autospec=True
+    ) as mock_home:
+        mock_instance = AsyncMock(spec=YoLinkHome)
+        mock_home.return_value = mock_instance
+        # Set up default return for async_get_home_info
+        mock_home_info = MagicMock()
+        mock_home_info.data = {"id": TEST_HOME_ID, "name": TEST_HOME_NAME}
+        mock_instance.async_get_home_info.return_value = mock_home_info
+        yield mock_home

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -1,13 +1,22 @@
 """Test yolink config flow."""
 
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from yolink.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
 from homeassistant import config_entries, setup
 from homeassistant.components import application_credentials
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -21,33 +30,91 @@ CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
 
+# UAC test credentials
+TEST_UAID = "test-uaid-12345"
+TEST_SECRET_KEY = "test-secret-key-6789"
+TEST_HOME_ID = "home_12345"
+TEST_HOME_NAME = "My Test Home"
 
-async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
-    """Check flow abort when no configuration."""
+
+async def test_user_flow_shows_menu(
+    hass: HomeAssistant,
+) -> None:
+    """Check that user flow shows menu."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    await application_credentials.async_import_client_credential(
+        hass,
+        DOMAIN,
+        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    )
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+    assert "pick_implementation" in result["menu_options"]
+    assert "uac" in result["menu_options"]
+
+
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
+    """Check flow abort when no configuration and selecting OAuth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    # Menu is shown first even without credentials
+    assert result["type"] is FlowResultType.MENU
+
+    # When selecting OAuth without credentials, it should abort
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
-async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
-    """Check flow abort when an entry already exist."""
-    MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN).add_to_hass(hass)
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_oauth_alongside_uac_entries(hass: HomeAssistant) -> None:
+    """Check that OAuth entries and UAC entries can coexist."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    await application_credentials.async_import_client_credential(
+        hass,
+        DOMAIN,
+        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    )
+    # Add a UAC entry first
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    # Menu should still be shown - UAC entry doesn't block OAuth
+    assert result["type"] is FlowResultType.MENU
+
+    # Selecting OAuth should proceed to the external step (not abort)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+    # Should show external step for OAuth (since only one implementation)
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
 
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_full_flow(
+async def test_full_oauth_flow(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Check full flow."""
+    """Check full OAuth flow via menu."""
     assert await setup.async_setup_component(
         hass,
         DOMAIN,
@@ -58,9 +125,18 @@ async def test_full_flow(
         DOMAIN,
         application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
+
+    # Start the flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.MENU
+
+    # Select OAuth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -99,6 +175,7 @@ async def test_full_flow(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["data"]["auth_implementation"] == DOMAIN
+    assert result["data"][CONF_AUTH_TYPE] == AUTH_TYPE_OAUTH
 
     result["data"]["token"].pop("expires_at")
     assert result["data"]["token"] == {
@@ -116,6 +193,250 @@ async def test_full_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
+async def test_uac_flow_success(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check successful UAC flow."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    # Select UAC
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+
+    # Enter credentials
+    with patch(
+        "homeassistant.components.yolink.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_HOME_NAME
+    assert result["data"] == {
+        CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+        CONF_UAID: TEST_UAID,
+        CONF_SECRET_KEY: TEST_SECRET_KEY,
+        CONF_HOME_ID: TEST_HOME_ID,
+    }
+
+
+async def test_uac_flow_invalid_auth(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with invalid credentials."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise auth error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = (
+        YoLinkAuthFailError("000103", "Invalid credentials")
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter bad credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "bad-uaid", CONF_SECRET_KEY: "bad-secret"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_uac_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with connection error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise connection error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = (
+        YoLinkClientError("000201", "Connection failed")
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_uac_flow_timeout(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with timeout error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise timeout error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = TimeoutError()
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_uac_flow_unknown_error(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check UAC flow with unknown error."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Make the mock raise unexpected error
+    mock_yolink_home_config_flow.return_value.async_setup.side_effect = RuntimeError(
+        "Unexpected"
+    )
+
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_multiple_uac_entries_different_homes(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check that multiple UAC entries for different homes are allowed."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Add first UAC entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="home_11111",
+        title="First Home",
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "first-uaid",
+            CONF_SECRET_KEY: "first-secret",
+            CONF_HOME_ID: "home_11111",
+        },
+    ).add_to_hass(hass)
+
+    # Set up mock for second home
+    mock_home_info = MagicMock()
+    mock_home_info.data = {"id": "home_22222", "name": "Second Home"}
+    mock_yolink_home_config_flow.return_value.async_get_home_info.return_value = (
+        mock_home_info
+    )
+
+    # Start the flow for second home
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials for second home
+    with patch(
+        "homeassistant.components.yolink.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: "second-uaid", CONF_SECRET_KEY: "second-secret"},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Second Home"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_uac_flow_duplicate_home(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Check that duplicate UAC entries for same home are prevented."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    # Add existing UAC entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    # Try to add same home again
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+
+    # Enter credentials for same home
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "new-uaid", CONF_SECRET_KEY: "new-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
     """Check yolink authorization timeout."""
@@ -129,12 +450,18 @@ async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
         DOMAIN,
         application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
     )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.LocalOAuth2Implementation.async_generate_authorize_url",
         side_effect=TimeoutError,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "pick_implementation"}
         )
 
     assert result["type"] is FlowResultType.ABORT
@@ -142,12 +469,12 @@ async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_reauthentication(
+async def test_oauth_reauthentication(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test yolink reauthentication."""
+    """Test yolink OAuth reauthentication."""
     await setup.async_setup_component(
         hass,
         DOMAIN,
@@ -165,6 +492,7 @@ async def test_reauthentication(
         unique_id=DOMAIN,
         version=1,
         data={
+            CONF_AUTH_TYPE: AUTH_TYPE_OAUTH,
             "refresh_token": "outdated_fresh_token",
             "access_token": "outdated_access_token",
         },
@@ -213,3 +541,90 @@ async def test_reauthentication(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_uac_reauthentication(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Test yolink UAC reauthentication."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        version=1,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    )
+    old_entry.add_to_hass(hass)
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    # Confirm reauth
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+
+    # Enter new credentials
+    with patch(
+        "homeassistant.components.yolink.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_UAID: "new-uaid", CONF_SECRET_KEY: "new-secret"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert old_entry.data[CONF_UAID] == "new-uaid"
+    assert old_entry.data[CONF_SECRET_KEY] == "new-secret"
+
+
+async def test_uac_reauthentication_wrong_account(
+    hass: HomeAssistant,
+    mock_yolink_home_config_flow: AsyncMock,
+) -> None:
+    """Test yolink UAC reauthentication with wrong account."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        version=1,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    )
+    old_entry.add_to_hass(hass)
+
+    # Set up mock to return different home_id
+    mock_home_info = MagicMock()
+    mock_home_info.data = {"id": "different_home_id", "name": "Different Home"}
+    mock_yolink_home_config_flow.return_value.async_get_home_info.return_value = (
+        mock_home_info
+    )
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    # Enter credentials for different home
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "different-uaid", CONF_SECRET_KEY: "different-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"


### PR DESCRIPTION
## Summary

- Add User Access Credentials (UAC) authentication alongside OAuth2
- Enable users to configure multiple YoLink homes (one per UAC entry)
- Add menu-based config flow for authentication method selection
- Preserve backwards compatibility with existing OAuth entries

## Problem

The current YoLink integration has two limitations preventing multi-home support:

1. **Single Instance Restriction**: `config_flow.py` uses `DOMAIN` as the unique ID, blocking multiple config entries
2. **Default Home Only**: OAuth2 credentials only access the default home

## Solution

- Add `UACAuth` class using `YoLinkAuthMgr` base class (compatible with yolink-api 0.5.9)
- Use `home_id` as unique identifier for UAC entries (allows unlimited homes)
- Keep OAuth entries using `DOMAIN` as unique_id (one allowed, backwards compatible)
- Menu in config flow lets users choose between OAuth and UAC

## How Users Get UAC Credentials

1. Open **YoLink App** on phone
2. Go to **Settings** → **Account** → **Advanced Settings**
3. Tap **User Access Credentials**
4. Create a new UAC and **select the specific Home** to access
5. Copy the **UAID** and **Secret Key**
6. Repeat for each home to add to Home Assistant

## yolink-api 0.5.9 Compatibility Notes

The `UACAuth` class implements token fetching manually because `YoLinkLocalAuthMgr` is not available in yolink-api 0.5.9. Key implementation details:

- Uses `YoLinkAuthMgr` abstract base class
- `access_token()` is a method (not property) - required by library's `http_auth_header()`
- Token fetching uses `client_credentials` OAuth2 grant type

For future yolink-api versions (if `YoLinkLocalAuthMgr` becomes available):
- Consider switching to `YoLinkLocalAuthMgr` as base class
- Remove manual `_fetch_token()` logic

## Debugging UAC Authentication Issues

If users experience authentication problems, enable debug logging:

```yaml
logger:
  default: info
  logs:
    homeassistant.components.yolink: debug
```

**Debug log messages:**
- `"Fetching UAC token from..."` - Token request initiated
- `"Token response status: X"` - HTTP response status
- `"Token response keys: [...]"` - Response contains expected fields
- `"Successfully fetched access token"` - Token obtained successfully

**Common errors:**
- **"Invalid authentication"** (401/403): UAID or Secret Key incorrect
- **"Failed to connect"**: Network issue or API endpoint unreachable
- **"UAC validation timed out"**: API response took > 10 seconds

**Verify credentials directly:**
```bash
curl -X POST https://api.yosmart.com/open/yolink/token \
  -d "grant_type=client_credentials&client_id=YOUR_UAID&client_secret=YOUR_SECRET"
```

## Test plan

- [x] Fresh install with UAC credentials works
- [x] Fresh install with OAuth2 still works (backward compatibility)
- [x] Multiple UAC entries for different homes work
- [x] Reauth flow works for UAC entries
- [x] Reauth flow works for OAuth entries
- [x] Existing OAuth entries continue to work
- [x] All 15 config flow tests pass
- [x] Manual testing on real HA instance

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
